### PR TITLE
Add toy JIT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+out/basic-cpp-jit
+out/basic-cpp-jit-no-fp

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,21 @@
 EH_FRAME_BIN = ../dist/eh-frame
 
+all: lint build
+
 lint:
 	clang-format -i src/*
+
 build:
-	gcc src/basic-cpp.cpp -o out/basic-cpp
+	gcc src/basic-cpp.cpp -o out/basic-cpp -g
 	gcc src/basic-cpp-plt.cpp -o out/basic-cpp-plt
 	gcc src/basic-cpp.cpp -o out/basic-cpp-no-fp -fomit-frame-pointer
 	gcc src/basic-cpp.cpp -o out/basic-cpp-no-fp-with-debuginfo -fomit-frame-pointer -g
 	gcc src/basic-cpp-plt.cpp -o out/basic-cpp-plt-pie -pie -fPIE
 	gcc src/basic-cpp-plt.cpp -o out/basic-cpp-plt-hardened -pie -fPIE -fstack-protector-all -D_FORTIFY_SOURCE=2 -Wl,-z,now -Wl,-z,relro -O2
+	# The JIT code has frame pointers.
+	gcc src/basic-cpp-jit.cpp -o out/basic-cpp-jit -g
+	gcc src/basic-cpp-jit.cpp -o out/basic-cpp-jit-no-fp -fomit-frame-pointer -g
+
 
 validate:
 	$(EH_FRAME_BIN) --executable out/basic-cpp > tables/ours_basic-cpp.txt

--- a/src/basic-cpp-jit.cpp
+++ b/src/basic-cpp-jit.cpp
@@ -1,0 +1,197 @@
+#include <errno.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+// This implements a simple JIT for x86_64 with support for symbolization
+// with perfmap. We don't use any JIT framework or assembler for the sake
+// of simplicity.
+
+// Some tools have heuristics to unwind the stack even
+// with frame pointers *and* unwind information omitted.
+#define ENABLE_FRAME_POINTERS_IN_JIT true
+// Amount of items to push into the stack to simulate a
+// more realistic stack usage. Otherwise stack unwinding with
+// frame pointers might work by accident.
+#define STACK_ITEMS 30
+
+int __attribute__((noinline)) aot_top() {
+  for (int i = 0; i < 1000; i++) {
+  }
+
+  return 0;
+}
+
+// ahead of time
+int __attribute__((noinline)) aot2() { return aot_top(); }
+
+int __attribute__((noinline)) aot1() { return aot2(); }
+
+int __attribute__((noinline)) aot() { return aot1(); }
+
+void add_preamble(char **mem) {
+  if (!ENABLE_FRAME_POINTERS_IN_JIT) {
+    return;
+  }
+
+  *(*mem)++ = 0x55; // push   %rbp
+  *(*mem)++ = 0x48; // mov    %rsp,%rbp
+  *(*mem)++ = 0x89;
+  *(*mem)++ = 0xe5; //   < difference between this and 0xec?
+}
+
+void add_epilogue(char **mem) {
+  if (!ENABLE_FRAME_POINTERS_IN_JIT) {
+    return;
+  }
+  *(*mem)++ = 0x5d; // pop    %rbp
+}
+
+// Add arbitrary on the stack to change stack
+// pointer.
+void push_stuff_to_stack(char **mem) {
+  for (int i = 0; i < STACK_ITEMS; i++) {
+    *(*mem)++ = 0x68; // push   0xfafafa
+    *(*mem)++ = 0xfa;
+    *(*mem)++ = 0xfa;
+    *(*mem)++ = 0xfa;
+    *(*mem)++ = 0x00;
+  }
+}
+// Pop the stack and discard
+void pop_stuff_from_stack(char **mem) {
+  for (int i = 0; i < STACK_ITEMS; i++) {
+    *(*mem)++ = 0x48; // add    rsp,0x8.
+    *(*mem)++ = 0x83;
+    *(*mem)++ = 0xc4;
+    *(*mem)++ = 0x08;
+  }
+}
+
+int main() {
+  size_t jit_size = 5000;
+  char *mem = (char *)mmap(NULL, jit_size, PROT_READ | PROT_WRITE | PROT_EXEC,
+                           MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  if (mem == (void *)-1) {
+    printf("mmap failed: %s\n", strerror(errno));
+    return -1;
+  }
+  char *mem_start = mem;
+  printf("jit segment starts at: %p\n", mem_start);
+  void (*jit_func)() = (void (*)())mem_start;
+
+  // ===== Entrypoint function =====
+  unsigned long long jit1_first_addr = (unsigned long long)mem;
+  add_preamble(&mem);
+  push_stuff_to_stack(&mem);
+
+  // Body
+  *mem++ = 0x48; // movabs $rax, number
+  *mem++ = 0xb8;
+  char *to_call = mem;
+  // We don't know this address yet, will fix up later.
+  for (int i = 0; i < 8; i++) {
+    *mem++ = 0x00;
+  }
+
+  *mem++ = 0xff; // call   rax
+  *mem++ = 0xd0;
+
+  pop_stuff_from_stack(&mem);
+  add_epilogue(&mem);
+  *mem++ = 0xc3; // ret
+
+  unsigned long long jit1_last_addr = (unsigned long long)mem;
+
+  // Fix up address we will jump to, we could have done a relative
+  // jump but I preferred being explicit.
+  unsigned long long second_routine = (unsigned long long)mem;
+  // Done explicitly for clarity
+  *to_call++ = (second_routine & 0xFF) >> 0;
+  *to_call++ = (second_routine & 0xFF00) >> 8;
+  *to_call++ = (second_routine & 0xFF0000) >> 16;
+  *to_call++ = (second_routine & 0xFF000000) >> 24;
+  *to_call++ = (second_routine & 0xFF00000000) >> 32;
+  *to_call++ = (second_routine & 0xFF0000000000) >> 40;
+  *to_call++ = (second_routine & 0xFF000000000000) >> 48;
+  *to_call++ = (second_routine & 0xFF00000000000000) >> 56;
+
+  // ===== Leaf func =====
+  unsigned long long jit2_first_addr = (unsigned long long)mem;
+  add_preamble(&mem);
+  push_stuff_to_stack(&mem);
+
+  // Body
+  *mem++ = 0xc7; // movl   $0x0,-0x4(%rbp)
+  *mem++ = 0x45;
+  *mem++ = 0xfc;
+  *mem++ = 0x00;
+  *mem++ = 0x00;
+  *mem++ = 0x00;
+  *mem++ = 0x00;
+  *mem++ = 0xeb; // jmp    <first cmpl below>
+  *mem++ = 0x04;
+  *mem++ = 0x83; // addl   $0x1,-0x4(%rbp)
+  *mem++ = 0x45;
+  *mem++ = 0xfc;
+  *mem++ = 0x01;
+  *mem++ = 0x81; // cmpl   $0x3e7,-0x4(%rbp) // <- 999 (1000 iters - 1)
+  *mem++ = 0x7d;
+  *mem++ = 0xfc;
+  *mem++ = 0xe7;
+  *mem++ = 0x03;
+  *mem++ = 0x00;
+  *mem++ = 0x00;
+  *mem++ = 0x7e; // jle    0x401153 <first addl above>
+  *mem++ = 0xf3;
+
+  pop_stuff_from_stack(&mem);
+  add_epilogue(&mem);
+  *mem++ = 0xc3; // ret
+
+  unsigned long long jit2_last_addr = (unsigned long long)mem;
+
+  // We are done writing code, let's not make it writable anymore.
+  mprotect(mem_start, jit_size, PROT_EXEC);
+
+  // Write perfmap so perf can symbolize the jitted functions.
+  //
+  // https://github.com/torvalds/linux/blob/master/tools/perf/Documentation/jit-interface.txt
+  char path[100];
+  sprintf(path, "/tmp/perf-%d.map", getpid());
+  printf("path for jitdump: %s\n", path);
+
+  FILE *file = fopen(path, "w+");
+  if (file == NULL) {
+    printf("fopen failed: %s\n", strerror(errno));
+    exit(1);
+  }
+
+  fprintf(file, "%llx %llx %s\n", jit1_first_addr,
+          jit1_last_addr - jit1_first_addr, "jit_middle");
+  fprintf(file, "%llx %llx %s\n", jit2_first_addr,
+          jit2_last_addr - jit2_first_addr, "jit_top");
+
+  fclose(file);
+
+  while (true) {
+    jit_func();
+    aot();
+  }
+  return 0;
+}
+
+// Notes:
+//
+// - GDB doesn't seem to use perfmap;
+// - GDB complains about our stack;
+// (gdb) bt
+// #0  0x00007ffff7fbe023 in ?? ()
+// #1 a 0x00007fffffffd8f0 in ?? ()
+// #2  0x00007ffff7fbe010 in ?? ()
+// #3 a 0x00007fffffffd9d0 in ?? ()
+// #4  0x00000000004016a8 in main () at src/basic-cpp.cpp:135
+// Backtrace stopped: previous frame inner to this frame (corrupt stack?)


### PR DESCRIPTION
Test Plan
======

```
$ make build && perf record -g out/basic-cpp-jit
gcc src/basic-cpp.cpp -o out/basic-cpp -g
gcc src/basic-cpp-plt.cpp -o out/basic-cpp-plt
gcc src/basic-cpp.cpp -o out/basic-cpp-no-fp -fomit-frame-pointer
gcc src/basic-cpp.cpp -o out/basic-cpp-no-fp-with-debuginfo -fomit-frame-pointer -g
gcc src/basic-cpp-plt.cpp -o out/basic-cpp-plt-pie -pie -fPIE
gcc src/basic-cpp-plt.cpp -o out/basic-cpp-plt-hardened -pie -fPIE -fstack-protector-all -D_FORTIFY_SOURCE=2 -Wl,-z,now -Wl,-z,relro -O2
# The JIT code has frame pointers.
gcc src/basic-cpp-jit.cpp -o out/basic-cpp-jit -g
gcc src/basic-cpp-jit.cpp -o out/basic-cpp-jit-no-fp -fomit-frame-pointer -g
jit segment starts at: 0x7fc248831000
path for jitdump: /tmp/perf-76175.map
^C[ perf record: Woken up 11 times to write data ]
[ perf record: Captured and wrote 2.737 MB perf.data (29931 samples) ]
```


```
$ perf report
+  100.00%     0.00%  basic-cpp-jit  libc.so.6             [.] __libc_start_call_main
+   99.93%     0.06%  basic-cpp-jit  basic-cpp-jit         [.] main
+   50.42%     0.65%  basic-cpp-jit  [JIT] tid 76175       [.] jit_middle
+   49.82%    49.80%  basic-cpp-jit  [JIT] tid 76175       [.] jit_top
+   49.44%     0.01%  basic-cpp-jit  basic-cpp-jit         [.] aot
+   49.43%     0.06%  basic-cpp-jit  basic-cpp-jit         [.] aot1
+   49.37%    49.35%  basic-cpp-jit  basic-cpp-jit         [.] aot_top
+   49.35%     0.02%  basic-cpp-jit  basic-cpp-jit         [.] aot2
     0.03%     0.03%  basic-cpp-jit  [unknown]             [k] 0xffffffff840011b7
     0.00%     0.00%  basic-cpp-jit  libc.so.6             [.] __getpid
```

https://pprof.me/1a28580 (note that we don't have support for mixed-mode unwinding yet)